### PR TITLE
core: fix for passing kwargs to constructor

### DIFF
--- a/invenio_db/core.py
+++ b/invenio_db/core.py
@@ -39,12 +39,14 @@ class InvenioDB(object):
 
     def __init__(self, app=None, **kwargs):
         """Extension initialization."""
+        self.kwargs = kwargs
         if app:
             self.init_app(app, **kwargs)
 
     def init_app(self, app, **kwargs):
         """Initialize application object."""
-        self.init_db(app, **kwargs)
+        self.kwargs.update(kwargs)
+        self.init_db(app, **self.kwargs)
         app.extensions['invenio-db'] = self
         app.cli.add_command(db_cmd)
 


### PR DESCRIPTION
* Fixes issue when passing kwargs to contructor and app is set to None.
  (closes #5)

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>