### PR TITLE
core: automatic orm mapper configuration

### DIFF
--- a/invenio_db/core.py
+++ b/invenio_db/core.py
@@ -29,6 +29,7 @@ from __future__ import absolute_import, print_function
 import os
 
 import pkg_resources
+import sqlalchemy as sa
 
 from .cli import db as db_cmd
 from .shared import db
@@ -66,3 +67,5 @@ class InvenioDB(object):
         if entrypoint_name:
             for base_entry in pkg_resources.iter_entry_points(entrypoint_name):
                 base_entry.load()
+
+        sa.orm.configure_mappers()


### PR DESCRIPTION
* Forces orm mapper configuration after all models are loaded in order
  to load mapper extensions like SQLAlchemy-Continuum.

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>