### PR TITLE
db: addition of versioning support

### DIFF
--- a/invenio_db/core.py
+++ b/invenio_db/core.py
@@ -31,6 +31,8 @@ import os
 import pkg_resources
 import sqlalchemy as sa
 
+from sqlalchemy_continuum import make_versioned
+
 from .cli import db as db_cmd
 from .shared import db
 
@@ -59,6 +61,9 @@ class InvenioDB(object):
             'sqlite:///' + os.path.join(app.instance_path, app.name + '.db')
         )
         app.config.setdefault('SQLALCHEMY_ECHO', app.debug)
+        app.config.setdefault('DB_VERSIONING_USER_MODEL', None)
+        with app.app_context():
+            make_versioned(user_cls=app.config['DB_VERSIONING_USER_MODEL'])
 
         # Initialize Flask-SQLAlchemy extension.
         db.init_app(app)

--- a/invenio_db/core.py
+++ b/invenio_db/core.py
@@ -30,8 +30,8 @@ import os
 
 import pkg_resources
 import sqlalchemy as sa
-
-from sqlalchemy_continuum import make_versioned
+from sqlalchemy_continuum import make_versioned, versioning_manager
+from sqlalchemy_continuum.builder import Builder
 
 from .cli import db as db_cmd
 from .shared import db
@@ -61,12 +61,35 @@ class InvenioDB(object):
             'sqlite:///' + os.path.join(app.instance_path, app.name + '.db')
         )
         app.config.setdefault('SQLALCHEMY_ECHO', app.debug)
-        app.config.setdefault('DB_VERSIONING_USER_MODEL', None)
-        with app.app_context():
-            make_versioned(user_cls=app.config['DB_VERSIONING_USER_MODEL'])
+        app.config.setdefault('DB_VERSIONING_USER_FROM_MODULE', None)
+        app.config.setdefault('DB_VERSIONING_ENABLED', True)
 
         # Initialize Flask-SQLAlchemy extension.
         db.init_app(app)
+
+        # Initialize versioning
+        if app.config['DB_VERSIONING_ENABLED'] is True:
+            with app.app_context():
+                module_name = app.config['DB_VERSIONING_USER_FROM_MODULE']
+                user_model = None
+                for entry in pkg_resources.iter_entry_points(
+                        'invenio_db.versioning.user_model'):
+                    if module_name and entry.module_name.startswith(
+                            module_name):
+                        user_model = entry.load()
+                        break
+
+                if module_name and user_model is None:
+                    raise RuntimeError('Could not find invenio_db.versioning '
+                                       'user_model specified in DB_VERSIONING'
+                                       '_USER_FROM_MODULE: {0}'.
+                                       format(module_name))
+
+                make_versioned(user_cls=user_model)
+                for clazz in db.Model._decl_class_registry.values():
+                    builder = versioning_manager.builder
+                    mapper = sa.orm.mapper
+                    builder.instrument_versioned_classes(mapper, clazz)
 
         # Initialize model bases
         if entrypoint_name:
@@ -74,3 +97,6 @@ class InvenioDB(object):
                 base_entry.load()
 
         sa.orm.configure_mappers()
+
+    def init_versioning(self):
+        pass

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,9 @@ extras_require = {
     'postgresql': [
         'psycopg2>=2.6.1',
     ],
+    'versioning': [
+        'SQLAlchemy-Continuum>=1.2.1',
+    ],
     'tests': tests_require,
 }
 
@@ -71,7 +74,6 @@ install_requires = [
     'Flask-SQLAlchemy>=2.0',
     'SQLAlchemy>=1.0',
     'SQLAlchemy-Utils>=0.31.0',
-    'SQLAlchemy-Continuum>=1.2.1',
 ]
 
 packages = find_packages()

--- a/setup.py
+++ b/setup.py
@@ -69,8 +69,9 @@ setup_requires = [
 install_requires = [
     'Flask-CLI>=0.2.1',
     'Flask-SQLAlchemy>=2.0',
-    'SQLAlchemy-Utils>=0.31.0',
     'SQLAlchemy>=1.0',
+    'SQLAlchemy-Utils>=0.31.0',
+    'SQLAlchemy-Continuum>=1.2.1',
 ]
 
 packages = find_packages()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,17 +27,22 @@
 
 from __future__ import absolute_import, print_function
 
+import os
 import pytest
 from flask import Flask
 from flask_cli import FlaskCLI, ScriptInfo
 
-from invenio_db import InvenioDB
+from invenio_db import InvenioDB, db
 
 
 @pytest.fixture()
 def app():
     """Flask application fixture."""
     app = Flask(__name__)
+    app.config.update(
+        SQLALCHEMY_DATABASE_URI=os.environ.get('SQLALCHEMY_DATABASE_URI',
+                                               'sqlite:///')
+    )
     FlaskCLI(app)
     return app
 

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Versioning tests for Invenio-DB"""
+
+from invenio_db import InvenioDB, db
+
+from sqlalchemy_continuum import make_versioned
+
+
+def test_versioning(app):
+    """Test SQLAlchemy-Continuum versioning."""
+    class UnversionedArticle(db.Model):
+        """Unversioned test model."""
+
+        id = db.Column(db.Integer, primary_key=True)
+
+        name = db.Column(db.String)
+
+    class VersionedArticle(db.Model):
+        """Versioned test model."""
+
+        __versioned__ = {}
+
+        id = db.Column(db.Integer, primary_key=True)
+
+        name = db.Column(db.String)
+
+    InvenioDB(app)
+    with app.app_context():
+        db.create_all()
+
+        versioned = VersionedArticle()
+        unversioned = UnversionedArticle()
+
+        original_name = 'original_name'
+
+        versioned.name = original_name
+        unversioned.name = original_name
+
+        db.session.add(versioned)
+        db.session.add(unversioned)
+        db.session.commit()
+
+        assert unversioned.name == versioned.name
+
+        modified_name = 'modified_name'
+
+        versioned.name = modified_name
+        unversioned.name = modified_name
+        db.session.commit()
+
+        assert unversioned.name == modified_name
+        assert versioned.name == modified_name
+        assert versioned.versions[0].name == original_name
+        assert versioned.versions[1].name == versioned.name
+
+        versioned.versions[0].revert()
+        db.session.commit()
+
+        assert unversioned.name == modified_name
+        assert versioned.name == original_name
+
+        versioned.versions[1].revert()
+        db.session.commit()
+        assert unversioned.name == versioned.name


### PR DESCRIPTION
* Adds SQLAlchemy-Continuum support to Invenio-DB for
  versioning support.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>