### PR TITLE
alembic: warn on CheckConstraint

### DIFF
--- a/invenio_db/alembic/35c1075e6360_force_naming_convention.py
+++ b/invenio_db/alembic/35c1075e6360_force_naming_convention.py
@@ -25,7 +25,7 @@
 """Force naming convention."""
 
 import sqlalchemy as sa
-from alembic import op
+from alembic import op, util
 from sqlalchemy.engine.reflection import Inspector
 
 # revision identifiers, used by Alembic.
@@ -93,6 +93,9 @@ def upgrade():
                         batch_op.drop_constraint(uq['name'], type_='unique')
                         batch_op.create_unique_constraint(
                             op.f(c.name), uq['column_names'])
+                elif isinstance(c, sa.schema.CheckConstraint):
+                    util.warn('Update {0.table.name} CHECK {0.name} '
+                              'manually'.format(c))
                 elif isinstance(c, sa.schema.Index):
                     key = tuple(c.columns.keys())
                     ix = ixs.get(key)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -146,6 +146,7 @@ def test_naming_convention(db, app):
             pk = sa.Column(sa.Integer, primary_key=True)
             name = sa.Column(sa.String(100), unique=True)
             city = sa.Column(sa.String(100), index=True)
+            active = sa.Column(sa.Boolean(name='active'), server_default='1')
 
         class Slave(base):
             __tablename__ = 'slave'


### PR DESCRIPTION
* Adds warning when discovered CheckConstraint instead of raising
  an exception.

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>