### PR TITLE
cli: alembic_version table manual drop

### DIFF
--- a/invenio_db/utils.py
+++ b/invenio_db/utils.py
@@ -28,7 +28,7 @@
 from flask import current_app
 from sqlalchemy.engine import reflection
 
-from invenio_db import db
+from .shared import db
 
 
 def rebuild_encrypted_properties(old_key, model, properties):
@@ -69,3 +69,12 @@ def rebuild_encrypted_properties(old_key, model, properties):
         model.query.filter_by(**primary_key_fields).\
             update(update_values)
     db.session.commit()
+
+
+def create_alembic_version_table():
+    """Create alembic_version table."""
+    alembic = current_app.extensions['invenio-db'].alembic
+    if not alembic.migration_context._has_version_table():
+        alembic.migration_context._ensure_version_table()
+        for head in alembic.script_directory.revision_map._real_heads:
+            alembic.migration_context.stamp(alembic.script_directory, head)


### PR DESCRIPTION
- Fixes sequence bug in transaction table.
 
- Adds to the cli drop command the alembic_version table.
   Addresses [#72](https://github.com/inveniosoftware/invenio-db/issues/72). 

Signed-off-by: Dinos Kousidis <konstantinos.kousidis@cern.ch>