### PR TITLE
tests: pydocstyle ignore D401

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,3 +33,6 @@ all_files = 1
 
 [bdist_wheel]
 universal = 1
+
+[pydocstyle]
+add_ignore = D401


### PR DESCRIPTION
- Ignores pydocstyle errors about first line imperative mood.
  (addresses inveniosoftware/troubleshooting#9)

Signed-off-by: Dinos Kousidis <konstantinos.kousidis@cern.ch>