### PR TITLE
release: v1.0.0b5

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,7 @@
 Changes
 =======
 
-Version 1.0.0b4 (released 2017-05-03)
+Version 1.0.0b5 (released 2017-05-12)
 -------------------------------------
 
 - Initial public release.

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -1,8 +1,8 @@
 =====================
- Invenio-DB v1.0.0b4
+ Invenio-DB v1.0.0b5
 =====================
 
-Invenio-DB v1.0.0b4 was released on May 3, 2017.
+Invenio-DB v1.0.0b5 was released on May 12, 2017.
 
 About
 -----
@@ -22,7 +22,7 @@ What's new
 Installation
 ------------
 
-   $ pip install invenio-db==1.0.0b4
+   $ pip install invenio-db==1.0.0b5
 
 Documentation
 -------------

--- a/invenio_db/version.py
+++ b/invenio_db/version.py
@@ -30,4 +30,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "1.0.0b4"
+__version__ = "1.0.0b5"


### PR DESCRIPTION
* Releases v1.0.0b5 just after v1.0.0b4 because pypi doesn't
  allow to reupload files and v1.0.0b4 has been rollbacked.

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>