### PR TITLE
wip alembic: fix in transaction recipe

### DIFF
--- a/invenio_db/alembic/dbdbc1b19cf2_create_transaction_table.py
+++ b/invenio_db/alembic/dbdbc1b19cf2_create_transaction_table.py
@@ -25,6 +25,8 @@
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.schema import Sequence, CreateSequence, \
+    DropSequence
 
 # revision identifiers, used by Alembic.
 revision = 'dbdbc1b19cf2'
@@ -40,10 +42,14 @@ def upgrade():
         sa.Column('issued_at', sa.DateTime(), nullable=True),
         sa.Column('id', sa.BigInteger(), nullable=False),
         sa.Column('remote_addr', sa.String(length=50), nullable=True),
-        sa.PrimaryKeyConstraint('id')
     )
+    op.create_primary_key('pk_transaction', 'transaction', ['id'])
+    if op._proxy.migration_context.dialect.supports_sequences:
+        op.execute(CreateSequence(Sequence('transaction_id_seq')))
 
 
 def downgrade():
     """Downgrade database."""
     op.drop_table('transaction')
+    if op._proxy.migration_context.dialect.supports_sequences:
+        op.execute(DropSequence(Sequence('transaction_id_seq')))

--- a/invenio_db/cli.py
+++ b/invenio_db/cli.py
@@ -32,14 +32,11 @@ import click
 from click import _termui_impl
 from flask import current_app
 from flask.cli import with_appcontext
-from sqlalchemy.exc import InternalError
-from sqlalchemy.schema import DropTable
-from sqlalchemy.sql.ddl import SchemaDropper
 from sqlalchemy_utils.functions import create_database, database_exists, \
     drop_database
 from werkzeug.local import LocalProxy
 
-from .utils import create_alembic_version_table
+from .utils import create_alembic_version_table, drop_alembic_version_table
 
 _db = LocalProxy(lambda: current_app.extensions['sqlalchemy'].db)
 
@@ -86,19 +83,12 @@ def create(verbose):
 def drop(verbose):
     """Drop tables."""
     click.secho('Dropping all tables!', fg='red', bold=True)
-    schema_dropper = SchemaDropper(_db.engine.dialect, _db.engine.connect())
     with click.progressbar(reversed(_db.metadata.sorted_tables)) as bar:
         for table in bar:
             if verbose:
                 click.echo(' Dropping table {0}'.format(table))
-            try:
                 table.drop(bind=_db.engine, checkfirst=True)
-            except InternalError:
-                schema_dropper.connection.execute(DropTable(table))
-    if _db.engine.dialect.has_table(_db.engine, 'alembic_version'):
-        alembic_version = _db.Table('alembic_version', _db.metadata,
-                                    autoload_with=_db.engine)
-        alembic_version.drop(bind=_db.engine)
+        drop_alembic_version_table()
     click.secho('Dropped all tables!', fg='green')
 
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ extras_require = {
         'psycopg2>=2.6.1',
     ],
     'versioning': [
-        'SQLAlchemy-Continuum>=1.2.1',
+        'SQLAlchemy-Continuum>=1.3',
     ],
     'tests': tests_require,
 }


### PR DESCRIPTION
- Fixes creation of sequence in transaction table,
  to make it able to drop

- Adds a utility function to drop the alembic_version table
  Closes [#83](https://github.com/inveniosoftware/invenio-db/issues/83)

Signed-off-by: Dinos Kousidis <konstantinos.kousidis@cern.ch>