### PR TITLE
global: avoid double versioned models registration

### DIFF
--- a/invenio_db/ext.py
+++ b/invenio_db/ext.py
@@ -35,6 +35,7 @@ from sqlalchemy_utils.functions import get_class_by_table
 
 from .cli import db as db_cmd
 from .shared import db
+from .utils import versioning_models_registered
 
 
 class InvenioDB(object):
@@ -95,7 +96,8 @@ class InvenioDB(object):
         if app.config['DB_VERSIONING']:
             manager = self.versioning_manager
             if manager.pending_classes:
-                manager.builder.configure_versioned_classes()
+                if not versioning_models_registered(manager, database.Model):
+                    manager.builder.configure_versioned_classes()
             elif 'transaction' not in database.metadata.tables:
                 manager.declarative_base = database.Model
                 manager.create_transaction_model()

--- a/invenio_db/utils.py
+++ b/invenio_db/utils.py
@@ -89,3 +89,19 @@ def drop_alembic_version_table():
         alembic_version = _db.Table('alembic_version', _db.metadata,
                                     autoload_with=_db.engine)
         alembic_version.drop(bind=_db.engine)
+
+
+def versioning_model_classname(manager, model):
+    """Get the name of the versioned model class."""
+    if manager.options.get('use_module_name', True):
+        return '%s%sVersion' % (
+            model.__module__.title().replace('.', ''), model.__name__)
+    else:
+        return '%sVersion' % (model.__name__,)
+
+
+def versioning_models_registered(manager, base):
+    """Return True if all versioning models have been registered."""
+    declared_models = base._decl_class_registry.keys()
+    return all(versioning_model_classname(manager, c) in declared_models
+               for c in manager.pending_classes)


### PR DESCRIPTION
* Checks for already registered models before building versioning
  models. (closes #96)