### PR TITLE
Fix: Pin SQLAlchemy-Continuum

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ extras_require = {
         'psycopg2-binary>=2.7.4',
     ],
     'versioning': [
-        'SQLAlchemy-Continuum>=1.3',
+        'SQLAlchemy-Continuum>=1.3,<1.3.5',
     ],
     'tests': tests_require,
 }


### PR DESCRIPTION
Pin SQLAlchemy-Continuum upper version limit (<1.3.5) to avoid crashing due to https://github.com/kvesteri/sqlalchemy-continuum/issues/188