### PR TITLE
dependencies: cap sqlalchemy to <1.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ install_requires = [
     'invenio-base>=1.2.3',
     'Flask-Alembic>=2.0.1',
     'Flask-SQLAlchemy>=2.1',
-    'SQLAlchemy>=1.2.18',
+    'SQLAlchemy>=1.2.18,<1.4.0',
     'SQLAlchemy-Utils>=0.33.1,<0.36',
 ]
 


### PR DESCRIPTION
closes #141 