### PR TITLE
cap flask-sqlalchemy below 2.5

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@
 Changes
 =======
 
+Version 1.0.9 (released 2021-03-18)
+
+- Pins Flask-SQLAlchemy below 2.5 due to breaking changes. Perhaps to revisit when fixed.
+
 Version 1.0.8 (released 2020-11-16)
 
 - Pins SQLAlchemy to >=1.2.18 and <1.4 due to incompatibility between

--- a/invenio_db/version.py
+++ b/invenio_db/version.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2020 CERN.
+# Copyright (C) 2021 Northwestern University.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -12,4 +13,4 @@ This file is imported by ``invenio_db.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = '1.0.8'
+__version__ = '1.0.9'

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2020 CERN.
+# Copyright (C) 2021 Northwestern University.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -44,7 +45,7 @@ for reqs in extras_require.values():
 install_requires = [
     'invenio-base>=1.2.3',
     'Flask-Alembic>=2.0.1',
-    'Flask-SQLAlchemy>=2.1',
+    'Flask-SQLAlchemy>=2.1,<2.5.0',
     'SQLAlchemy>=1.2.18,<1.4.0',
     'SQLAlchemy-Utils>=0.33.1,<0.36',
 ]


### PR DESCRIPTION
Flask-SQLAlchemy was released a couple hours ago and is breaking things. Until it's patched, we shouldn't depend on it.