### PR TITLE
alembic: one transaction per migration

### DIFF
--- a/invenio_db/ext.py
+++ b/invenio_db/ext.py
@@ -49,6 +49,9 @@ class InvenioDB(object):
                 'script_location': script_location,
                 'version_locations': version_locations,
         })
+        app.config.setdefault('ALEMBIC_CONTEXT', {
+            'transaction_per_migration': True,
+        })
 
         self.alembic.init_app(app)
         app.extensions['invenio-db'] = self

--- a/invenio_db/utils.py
+++ b/invenio_db/utils.py
@@ -99,4 +99,7 @@ def alembic_test_context():
         if name == 'ix_uq_partial_files_object_is_head':
             return False
         return True
-    return {'include_object': include_object}
+    return {
+        'transaction_per_migration': True,
+        'include_object': include_object,
+    }


### PR DESCRIPTION
* By default Alembic uses a single transaction for running all
  migrations. This however makes it very hard to write migration scripts
  that work on both PostgreSQL and MySQL.