### PR TITLE
[WIP] Flask21

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@
 Changes
 =======
 
+Version 1.0.15 (released 2022-03-31)
+
+- Bumps min version of SQLAlchemy-Utils to v0.37 due to Flask 2.1
+  incompatibilities.
+
 Version 1.0.14 (released 2022-03-30)
 
 - Adds support for SQLAlchemy 1.4 and Flask v2.1.

--- a/invenio_db/__init__.py
+++ b/invenio_db/__init__.py
@@ -91,7 +91,7 @@ version locations is assembled from ``invenio_db.alembic`` entry point group.
 from .ext import InvenioDB
 from .shared import db
 
-__version__ = '1.0.14'
+__version__ = '1.0.15'
 
 __all__ = (
     '__version__',

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     # Update constraints-min.txt if you update invenio-base version.
     invenio-base>=1.2.10
     SQLAlchemy-Continuum>=1.3.12
-    SQLAlchemy-Utils>=0.33.1,<0.39
+    SQLAlchemy-Utils>=0.37,<0.39
     SQLAlchemy>=1.2.18,<1.5.0
 
 [options.extras_require]


### PR DESCRIPTION
lower versions than v0.36 will break due to [this import](https://github.com/kvesteri/sqlalchemy-utils/blob/0.35.0/sqlalchemy_utils/expressions.py#L5).