### PR TITLE
alembic: fix sqlalchemy op.execute() due to latest sqlalchamy-continuum

### DIFF
--- a/invenio_db/alembic/35c1075e6360_force_naming_convention.py
+++ b/invenio_db/alembic/35c1075e6360_force_naming_convention.py
@@ -11,6 +11,7 @@
 import sqlalchemy as sa
 from alembic import op, util
 from sqlalchemy import inspect
+from sqlalchemy.sql import text
 
 # revision identifiers, used by Alembic.
 revision = "35c1075e6360"
@@ -32,7 +33,7 @@ NAMING_CONVENTION = sa.util.immutabledict(
 
 def upgrade():
     """Upgrade database."""
-    op.execute("COMMIT")  # See https://bitbucket.org/zzzeek/alembic/issue/123
+    op.execute(text("COMMIT"))  # See https://bitbucket.org/zzzeek/alembic/issue/123
     ctx = op.get_context()
     metadata = ctx.opts["target_metadata"]
     metadata.naming_convention = NAMING_CONVENTION


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Please describe briefly your pull request.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
