### PR TITLE
workflows: switch to centralized workflows

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,3 +1,12 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021-2025 CERN.
+# Copyright (C) 2025 KTH Royal Institute of Technology.
+# Copyright (C) 2024 Graz University of Technology.
+#
+# Invenio is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
 name: Publish
 
 on:
@@ -6,28 +15,6 @@ on:
       - v*
 
 jobs:
-  Publish:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel
-
-      - name: Build package
-        run: |
-          python setup.py sdist bdist_wheel
-
-      - name: Publish on PyPI
-        uses: pypa/gh-action-pypi-publish@v1.3.1
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_token }}
+  build-n-publish:
+    uses: inveniosoftware/workflows/.github/workflows/pypi-publish.yml@master
+    secrets: inherit


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

I think GitHub has finally killed the 20.04 runners. https://github.com/inveniosoftware/invenio-db/actions/runs/16276806056 We should use the centralized workflow.


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
