### PR TITLE
Use `lock_timeout` for more reliable Alembic recipe execution

### DIFF
--- a/invenio_db/ext.py
+++ b/invenio_db/ext.py
@@ -10,19 +10,85 @@
 
 """Database management for Invenio."""
 
+import logging
 import os
+import random
+import time
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as package_version
 from importlib.resources import files
 
 import sqlalchemy as sa
+from flask import current_app
 from flask_alembic import Alembic
 from invenio_base.utils import entry_points
+from sqlalchemy.exc import OperationalError
 from sqlalchemy_utils.functions import get_class_by_table
 
 from .cli import db as db_cmd
 from .shared import db
 from .utils import versioning_models_registered
+
+logger = logging.getLogger(__name__)
+
+
+class InvenioAlembic(Alembic):
+    """Alembic with PostgreSQL lock_timeout and retry for safe migrations.
+
+    Sets lock_timeout on migration connections so DDL statements fail fast
+    instead of blocking reads indefinitely while waiting for exclusive locks.
+    On lock timeout, retries with exponential backoff. Already-applied
+    migrations are skipped on retry (transaction_per_migration stamps each
+    step).
+
+    See https://postgres.ai/blog/20210923-zero-downtime-postgres-schema-migrations-lock-timeout-and-retries
+
+    Configuration:
+
+    - ``DB_MIGRATION_LOCK_TIMEOUT``: PostgreSQL lock_timeout value
+      (default ``"1s"``). Set to ``"0"`` to disable.
+    - ``DB_MIGRATION_LOCK_TIMEOUT_RETRIES``: number of retries on lock
+      timeout (default ``5``).
+    """
+
+    def _set_lock_timeout(self):
+        """Set lock_timeout on all PostgreSQL migration connections."""
+        for ctx in self.migration_contexts.values():
+            if (
+                ctx.connection is not None
+                and ctx.connection.dialect.name == "postgresql"
+            ):
+                timeout = current_app.config.get("DB_MIGRATION_LOCK_TIMEOUT", "1s")
+                ctx.connection.execute(
+                    sa.text("SELECT set_config('lock_timeout', :val, false)"),
+                    {"val": timeout},
+                )
+
+    def run_migrations(self, fn, **kwargs):
+        """Run migrations with lock_timeout and retry on lock failure."""
+        max_retries = current_app.config.get("DB_MIGRATION_LOCK_TIMEOUT_RETRIES", 5)
+
+        for attempt in range(max_retries + 1):
+            self._set_lock_timeout()
+            try:
+                super().run_migrations(fn, **kwargs)
+                return
+            except OperationalError as e:
+                is_lock_timeout = hasattr(e.orig, "pgcode") and e.orig.pgcode == "55P03"
+                if not is_lock_timeout or attempt >= max_retries:
+                    raise
+                # Exponential backoff with jitter
+                delay = min(30, 0.5 * 2**attempt) * (0.5 + random.random() * 0.5)
+                logger.warning(
+                    "Migration lock timeout, retrying in %.1fs (%d/%d)",
+                    delay,
+                    attempt + 1,
+                    max_retries,
+                )
+                time.sleep(delay)
+                # Clear cached contexts — connection is dead after the error.
+                # Next access to migration_contexts creates fresh connections.
+                self._get_cache().clear()
 
 
 class InvenioDB(object):
@@ -30,7 +96,7 @@ class InvenioDB(object):
 
     def __init__(self, app=None, **kwargs):
         """Extension initialization."""
-        self.alembic = Alembic(run_mkdir=False, command_name="alembic")
+        self.alembic = InvenioAlembic(run_mkdir=False, command_name="alembic")
         if app:
             self.init_app(app, **kwargs)
 

--- a/invenio_db/ext.py
+++ b/invenio_db/ext.py
@@ -51,6 +51,10 @@ class InvenioAlembic(Alembic):
       timeout (default ``5``).
     """
 
+    def __init__(self, *args, **kwargs):
+        """Initialize InvenioAlembic."""
+        super().__init__(*args, **kwargs)
+
     def _set_lock_timeout(self):
         """Set lock_timeout on all PostgreSQL migration connections."""
         for ctx in self.migration_contexts.values():

--- a/tests/test_lock_timeout.py
+++ b/tests/test_lock_timeout.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2024 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Test migration lock_timeout support."""
+
+import os
+import threading
+import time
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.exc import OperationalError
+
+from invenio_db import InvenioDB
+
+requires_postgresql = pytest.mark.skipif(
+    not os.environ.get("SQLALCHEMY_DATABASE_URI", "").startswith("postgresql"),
+    reason="PostgreSQL required",
+)
+
+
+@requires_postgresql
+def test_alembic_lock_timeout(db, app):
+    """Test that lock_timeout is set on migration connections."""
+    ext = InvenioDB(app, entry_point_group=False, db=db)
+
+    with app.app_context():
+        ext.alembic.upgrade()
+        ctx = ext.alembic.migration_context
+        result = ctx.connection.execute(sa.text("SHOW lock_timeout")).scalar()
+        assert result == "1s"
+
+
+@requires_postgresql
+def test_alembic_lock_timeout_custom(db, app):
+    """Test that lock_timeout is configurable."""
+    app.config["DB_MIGRATION_LOCK_TIMEOUT"] = "10s"
+    ext = InvenioDB(app, entry_point_group=False, db=db)
+
+    with app.app_context():
+        ext.alembic.upgrade()
+        ctx = ext.alembic.migration_context
+        result = ctx.connection.execute(sa.text("SHOW lock_timeout")).scalar()
+        assert result == "10s"
+
+
+@requires_postgresql
+def test_alembic_lock_timeout_prevents_long_waits(db, app):
+    """Test that DDL fails fast when a table is locked by another transaction.
+
+    Simulates a real scenario: a long-running query holds ACCESS SHARE on a
+    table, and an ALTER TABLE (needing ACCESS EXCLUSIVE) hits lock_timeout
+    instead of blocking indefinitely.
+    """
+    app.config["DB_MIGRATION_LOCK_TIMEOUT"] = "1s"
+    ext = InvenioDB(app, entry_point_group=False, db=db)
+
+    with app.app_context():
+        ext.alembic.upgrade()
+        engine = db.engine
+
+        with engine.connect() as conn:
+            conn.execute(
+                sa.text("CREATE TABLE IF NOT EXISTS _lock_timeout_test (id int)")
+            )
+            conn.commit()
+
+        try:
+            lock_held = threading.Event()
+            ddl_done = threading.Event()
+
+            def hold_lock():
+                """Simulate a long-running transaction holding ACCESS SHARE."""
+                with engine.connect() as conn:
+                    with conn.begin():
+                        conn.execute(sa.text("SELECT * FROM _lock_timeout_test"))
+                        lock_held.set()
+                        ddl_done.wait(timeout=10)
+
+            t = threading.Thread(target=hold_lock)
+            t.start()
+            lock_held.wait(timeout=5)
+
+            # The migration connection has lock_timeout set — ALTER TABLE
+            # needs ACCESS EXCLUSIVE which conflicts with ACCESS SHARE,
+            # so this must fail within ~1s instead of blocking.
+            ctx = ext.alembic.migration_context
+            with pytest.raises(OperationalError, match="lock timeout"):
+                ctx.connection.execute(
+                    sa.text("ALTER TABLE _lock_timeout_test ADD COLUMN x int")
+                )
+
+            ddl_done.set()
+            t.join(timeout=5)
+        finally:
+            with engine.connect() as conn:
+                conn.execute(sa.text("DROP TABLE IF EXISTS _lock_timeout_test"))
+                conn.commit()
+
+
+@requires_postgresql
+def test_alembic_lock_timeout_retry(db, app, caplog):
+    """Test that migrations retry on lock timeout and eventually succeed.
+
+    Strategy: apply all migrations, downgrade to base, lock alembic_version
+    (which every migration step must write to), then upgrade with retries.
+    The first attempts fail at the version stamp, but once the lock is
+    released (~2s) a retry succeeds. PostgreSQL transactional DDL ensures
+    rolled-back steps leave no artifacts.
+    """
+    app.config["DB_MIGRATION_LOCK_TIMEOUT"] = "500ms"
+    app.config["DB_MIGRATION_LOCK_TIMEOUT_RETRIES"] = 10
+    ext = InvenioDB(app, entry_point_group=False, db=db)
+
+    with app.app_context():
+        # Apply all, then roll back to base so upgrade has real work to do.
+        ext.alembic.upgrade()
+        ext.alembic.downgrade(target="96e796392533")
+
+        engine = db.engine
+        lock_held = threading.Event()
+
+        def hold_lock_briefly():
+            """Lock alembic_version exclusively for ~2s."""
+            with engine.connect() as conn:
+                with conn.begin():
+                    conn.execute(
+                        sa.text("LOCK TABLE alembic_version IN ACCESS EXCLUSIVE MODE")
+                    )
+                    lock_held.set()
+                    time.sleep(2)
+
+        t = threading.Thread(target=hold_lock_briefly)
+        t.start()
+        lock_held.wait(timeout=5)
+
+        # upgrade() goes through run_migrations → lock_timeout on
+        # alembic_version INSERT → retry → eventually succeeds.
+        with caplog.at_level("WARNING", logger="invenio_db.ext"):
+            ext.alembic.upgrade()
+
+        t.join(timeout=10)
+
+        # Verify retries actually happened.
+        retry_msgs = [r for r in caplog.records if "lock timeout" in r.message]
+        assert len(retry_msgs) >= 1
+
+        # Verify migrations actually applied.
+        heads = {s.revision for s in ext.alembic.current()}
+        expected = set(ext.alembic.script_directory.get_heads())
+        assert heads == expected


### PR DESCRIPTION
DDL migrations acquire ACCESS EXCLUSIVE locks which can cause cascading
blocking on busy tables. This sets lock_timeout (default 1s) on
PostgreSQL migration connections so they fail fast instead of blocking
reads indefinitely. On lock_not_available (pgcode 55P03), retries with
exponential backoff and jitter. Already-applied steps are skipped on
retry thanks to transaction_per_migration version stamping.

Configurable via DB_MIGRATION_LOCK_TIMEOUT (default "1s", set "0" to
disable) and DB_MIGRATION_LOCK_TIMEOUT_RETRIES (default 5).

See also https://postgres.ai/blog/20210923-zero-downtime-postgres-schema-migrations-lock-timeout-and-retries and https://github.com/sqlalchemy/alembic/discussions/1690