### PR TITLE
fix(timezone): the implementation now converts all timezones differen…

### DIFF
--- a/invenio_db/shared.py
+++ b/invenio_db/shared.py
@@ -52,10 +52,11 @@ class UTCDateTime(TypeDecorator):
             msg = f"ERROR: value: {value} is not of type datetime, instead of type: {type(value)}"
             raise ValueError(msg)
 
-        if value.tzinfo in (None, timezone.utc):
-            return value.replace(tzinfo=timezone.utc)
+        if value.tzinfo not in (None, timezone.utc):
+            msg = f"Error: value: {value}, tzinfo: {value.tzinfo} doesn't have a tzinfo of None or timezone.utc."
+            raise ValueError(msg)
 
-        return value.astimezone(timezone.utc)
+        return value.replace(tzinfo=timezone.utc)
 
     def process_result_value(self, value, dialect):
         """Process value retrieving from database."""

--- a/invenio_db/shared.py
+++ b/invenio_db/shared.py
@@ -52,11 +52,10 @@ class UTCDateTime(TypeDecorator):
             msg = f"ERROR: value: {value} is not of type datetime, instead of type: {type(value)}"
             raise ValueError(msg)
 
-        if value.tzinfo not in (None, timezone.utc):
-            msg = f"Error: value: {value}, tzinfo: {value.tzinfo} doesn't have a tzinfo of None or timezone.utc."
-            raise ValueError(msg)
+        if value.tzinfo in (None, timezone.utc):
+            return value.replace(tzinfo=timezone.utc)
 
-        return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
 
     def process_result_value(self, value, dialect):
         """Process value retrieving from database."""
@@ -67,13 +66,10 @@ class UTCDateTime(TypeDecorator):
             msg = f"ERROR: value: {value} is not of type datetime."
             raise ValueError(msg)
 
-        if value.tzinfo not in (None, timezone.utc):
-            msg = (
-                f"Error: value: {value} doesn't have a tzinfo of None or timezone.utc."
-            )
-            raise ValueError(msg)
+        if value.tzinfo in (None, timezone.utc):
+            return value.replace(tzinfo=timezone.utc)
 
-        return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
 
 
 class Timestamp:

--- a/tests/test_utc.py
+++ b/tests/test_utc.py
@@ -153,20 +153,16 @@ def test_timestamp_with_tz(app, db: SQLAlchemy):
         db.session.commit()
 
     with app.app_context():
-        # In this case, PostgreSQL also shifts the inserted timestamp to UTC+1.
-        # However, it now also returns the timezone with the column correctly as UTC+1.
-        # To ensure we avoid unexpected behaviour as much as possible, UTCDateTime only
-        # accepts timestamps from PostgreSQL that are in UTC, and raises an exception for
-        # all other zones.
-        # So in this case correctness is preserved but as an added safety mechanism we still
-        # reject the value.
-        with pytest.raises(ValueError) as excinfo:
-            TestTimestampWithTZ.query.all()
+        # In this case, PostgreSQL shifts the inserted timestamp to UTC+1.
+        # However, it now also returns the timezone with the column correctly as UTC.
+        # To ensure we avoid unexpected behaviour as much as possible, UTCDateTime
+        # converts all timestamps from PostgreSQL that are not in UTC to UTC.
+        TestTimestampWithTZ.query.all()
 
         expected_shifted_datetime = expected_datetime.astimezone(
             timezone(timedelta(hours=1))
         )
-        assert str(expected_shifted_datetime) in str(excinfo.value)
+        assert expected_shifted_datetime == expected_datetime.astimezone(timezone.utc)
 
         db.session.commit()
 


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

The current validation/conversion is too strict: we cannot expect every PostgreSQL instance can be configured to UTC.
This PR converts every non-UTC timezone to UTC instead.
This is in preparation of a talk in a telecon as a discussion base!


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
