### PR TITLE
Fix alembic migrations - missing imports, incorrect ChoiceType

### DIFF
--- a/invenio_db/alembic/script.py.mako
+++ b/invenio_db/alembic/script.py.mako
@@ -10,6 +10,8 @@
 
 from alembic import op
 import sqlalchemy as sa
+import sqlalchemy_utils
+import invenio_db.shared
 ${imports if imports else ""}
 
 # revision identifiers, used by Alembic.

--- a/invenio_db/alembic/script.py.mako
+++ b/invenio_db/alembic/script.py.mako
@@ -5,6 +5,8 @@
 
 from alembic import op
 import sqlalchemy as sa
+import sqlalchemy_utils
+import invenio_db.shared
 ${imports if imports else ""}
 
 # revision identifiers, used by Alembic.

--- a/invenio_db/ext.py
+++ b/invenio_db/ext.py
@@ -29,7 +29,7 @@ from sqlalchemy_utils.functions import get_class_by_table
 
 from .cli import db as db_cmd
 from .shared import db
-from .utils import versioning_models_registered
+from .utils import alembic_render_item, versioning_models_registered
 
 logger = logging.getLogger(__name__)
 
@@ -126,13 +126,17 @@ class InvenioDB(object):
                 "version_locations": version_locations,
             },
         )
-        app.config.setdefault(
+        alembic_ctx = app.config.setdefault(
             "ALEMBIC_CONTEXT",
             {
                 "transaction_per_migration": True,
                 "compare_type": True,  # Allows to detect change of column type, accuracy depends on backend
             },
         )
+
+        # Add our render hook to influence how Alembic autogenerates migration scripts
+        if "render_item" not in alembic_ctx:
+            alembic_ctx["render_item"] = alembic_render_item
 
         self.alembic.init_app(app)
         app.extensions["invenio-db"] = self

--- a/invenio_db/ext.py
+++ b/invenio_db/ext.py
@@ -24,7 +24,7 @@ from sqlalchemy_utils.functions import get_class_by_table
 
 from .cli import db as db_cmd
 from .shared import db
-from .utils import versioning_models_registered
+from .utils import alembic_render_item, versioning_models_registered
 
 logger = logging.getLogger(__name__)
 
@@ -121,7 +121,7 @@ class InvenioDB(object):
                 "version_locations": version_locations,
             },
         )
-        app.config.setdefault(
+        alembic_ctx = app.config.setdefault(
             "ALEMBIC_CONTEXT",
             {
                 "transaction_per_migration": True,
@@ -135,6 +135,10 @@ class InvenioDB(object):
                 ],
             },
         )
+
+        # Add our render hook to influence how Alembic autogenerates migration scripts
+        if "render_item" not in alembic_ctx:
+            alembic_ctx["render_item"] = alembic_render_item
 
         self.alembic.init_app(app)
         app.extensions["invenio-db"] = self

--- a/invenio_db/utils.py
+++ b/invenio_db/utils.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2017-2018 CERN.
 # Copyright (C) 2022-2026 Graz University of Technology.
 # Copyright (C) 2026 University of Münster.
+# Copyright (C) 2026 CESNET z.s.p..
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -164,3 +165,44 @@ update_table_columns_column_type_to_datetime = partial(
     existing_type=_db.UTCDateTime,
     existing_nullable=True,
 )
+
+
+def alembic_render_item(type_, obj, autogen_context):
+    """Fix import generation and broken reprs for known types.
+
+    Alembic uses ``x.__repr__`` to generate the migration code. For ChoiceType,
+    it is broken - the generated repr does not include the ``choices`` argument.
+
+    This render function fixes it by emitting the ``choices`` argument explicitly.
+    """
+    if type_ == "type":
+        # --- ChoiceType fix ---------------------------------------------------
+        try:
+            from sqlalchemy_utils.types.choice import ChoiceType
+        except ImportError:
+            pass
+        else:
+            if isinstance(obj, ChoiceType):
+                from enum import Enum
+
+                from alembic.autogenerate.render import _repr_type
+
+                impl_repr = _repr_type(obj.impl_instance, autogen_context)
+
+                choices = obj.choices
+                if isinstance(choices, type) and issubclass(choices, Enum):
+                    # Enum class: emit ChoiceType(Severity, impl=sa.String(1))
+                    # and add the matching from-import.
+                    autogen_context.imports.add(
+                        f"from {choices.__module__} import {choices.__name__}"
+                    )
+                    return (
+                        f"sqlalchemy_utils.types.choice.ChoiceType("
+                        f"{choices.__name__}, impl={impl_repr})"
+                    )
+                else:
+                    # List-of-tuples: values may not be serialisable; render
+                    # only the impl type, which is all the migration needs.
+                    return impl_repr
+
+    return False  # let Alembic render the type normally

--- a/invenio_db/utils.py
+++ b/invenio_db/utils.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2017-2018 CERN.
 # SPDX-FileCopyrightText: 2022-2026 Graz University of Technology.
 # SPDX-FileCopyrightText: 2026 University of Münster.
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p..
 # SPDX-License-Identifier: MIT
 # from .signals import secret_key_changed
 
@@ -167,3 +168,44 @@ update_table_columns_column_type_to_datetime = partial(
     existing_type=_db.UTCDateTime,
     existing_nullable=True,
 )
+
+
+def alembic_render_item(type_, obj, autogen_context):
+    """Fix import generation and broken reprs for known types.
+
+    Alembic uses ``x.__repr__`` to generate the migration code. For ChoiceType,
+    it is broken - the generated repr does not include the ``choices`` argument.
+
+    This render function fixes it by emitting the ``choices`` argument explicitly.
+    """
+    if type_ == "type":
+        # --- ChoiceType fix ---------------------------------------------------
+        try:
+            from sqlalchemy_utils.types.choice import ChoiceType
+        except ImportError:
+            pass
+        else:
+            if isinstance(obj, ChoiceType):
+                from enum import Enum
+
+                from alembic.autogenerate.render import _repr_type
+
+                impl_repr = _repr_type(obj.impl_instance, autogen_context)
+
+                choices = obj.choices
+                if isinstance(choices, type) and issubclass(choices, Enum):
+                    # Enum class: emit ChoiceType(Severity, impl=sa.String(1))
+                    # and add the matching from-import.
+                    autogen_context.imports.add(
+                        f"from {choices.__module__} import {choices.__name__}"
+                    )
+                    return (
+                        f"sqlalchemy_utils.types.choice.ChoiceType("
+                        f"{choices.__name__}, impl={impl_repr})"
+                    )
+                else:
+                    # List-of-tuples: values may not be serialisable; render
+                    # only the impl type, which is all the migration needs.
+                    return impl_repr
+
+    return False  # let Alembic render the type normally

--- a/tests/demo/alembic/__init__.py
+++ b/tests/demo/alembic/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015-2018 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Demo alembic module."""

--- a/tests/demo/alembic/__init__.py
+++ b/tests/demo/alembic/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p..
+# SPDX-License-Identifier: MIT
+
+"""Demo alembic module."""

--- a/tests/demo/with_choice.py
+++ b/tests/demo/with_choice.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2026 CESNET z.s.p.o.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+"""Model with ChoiceType."""
+
+from enum import Enum
+
+from sqlalchemy_utils.types.choice import ChoiceType
+
+from invenio_db import db
+
+
+class Severity(Enum):
+    """Severity enum."""
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+USER_TYPES = [("admin", "Admin"), ("regular-user", "Regular user")]
+
+
+class ModelWithChoices(db.Model):
+    """A simple model with a ChoiceType column."""
+
+    __tablename__ = "with_choices"
+    pk = db.Column(db.Integer, primary_key=True)
+
+    enum_choice = db.Column(ChoiceType(Severity))
+    tuple_choice = db.Column(ChoiceType(USER_TYPES))

--- a/tests/demo/with_choice.py
+++ b/tests/demo/with_choice.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p..
+# SPDX-License-Identifier: MIT
+
+"""Model with ChoiceType."""
+
+from enum import Enum
+
+from sqlalchemy_utils.types.choice import ChoiceType
+
+from invenio_db import db
+
+
+class Severity(Enum):
+    """Severity enum."""
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+USER_TYPES = [("admin", "Admin"), ("regular-user", "Regular user")]
+
+
+class ModelWithChoices(db.Model):
+    """A simple model with a ChoiceType column."""
+
+    __tablename__ = "with_choices"
+    pk = db.Column(db.Integer, primary_key=True)
+
+    enum_choice = db.Column(ChoiceType(Severity))
+    tuple_choice = db.Column(ChoiceType(USER_TYPES))

--- a/tests/test_alembic_choice.py
+++ b/tests/test_alembic_choice.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2026 CESNET z.s.p.o.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from alembic.script import Script
+from mocks import MockEntryPoint
+from sqlalchemy import text
+
+from invenio_db.utils import drop_alembic_version_table
+
+
+def _mock_entry_points(group=None):
+    data = {
+        "invenio_db.models": [
+            MockEntryPoint(
+                name="demo.with_choice", value="demo.with_choice", group="test"
+            ),
+        ],
+        "invenio_db.alembic": [
+            MockEntryPoint(name="demo", value="demo:alembic", group="test"),
+        ],
+    }
+    if group:
+        return data.get(group, [])
+    return data
+
+
+def drop_transaction_table(db):
+    connection = db.engine.connect()
+    connection.execute(text("DROP TABLE IF EXISTS transaction;"))
+    connection.execute(text("DROP SEQUENCE IF EXISTS transaction_id_seq;"))
+    connection.commit()
+    connection.close()
+
+
+@patch("importlib.metadata.entry_points", _mock_entry_points)
+def test_alembic(app, db):
+    """Test alembic recipes."""
+    from invenio_db.ext import InvenioDB
+
+    ext = InvenioDB(app, db=db)
+
+    if db.engine.name == "sqlite":
+        raise pytest.skip("Upgrades are not supported on SQLite.")
+
+    generated_paths = []
+    try:
+        db.drop_all()
+        drop_alembic_version_table()
+        drop_transaction_table(db)
+
+        with app.app_context():
+            # drop transaction table and sequence
+            ext.alembic.upgrade()
+
+            # generate a migration
+            result = ext.alembic.revision(
+                "Initial branch",
+                branch="demo",
+                parent="dbdbc1b19cf2",
+                empty=True,
+                splice=True,
+            )[0]
+            generated_paths.append(result.path)
+            # need to sleep to avoid timestamp collision (hash is computed from timestamp)
+            time.sleep(2)
+            ext.alembic.upgrade()
+            result = ext.alembic.revision("Choice test", branch="demo")[0]
+            generated_paths.append(result.path)
+
+            content = Path(result.path).read_text()
+
+            # check that imports have been added
+            assert "import sqlalchemy_utils" in content
+            assert "import invenio_db.shared" in content
+            assert "from demo.with_choice import Severity" in content
+            assert (
+                "sa.Column('enum_choice', sqlalchemy_utils.types.choice.ChoiceType(Severity, impl=sa.Unicode(length=255))"
+                in content
+            )
+            assert "sa.Column('tuple_choice', sa.Unicode(length=255)" in content
+
+            # upgrade to the new migration to check it works
+            ext.alembic.upgrade()
+
+        # Cleanup
+        db.drop_all()
+        drop_alembic_version_table()
+        drop_transaction_table(db)
+    finally:
+        for path in generated_paths:
+            Path(path).unlink()

--- a/tests/test_alembic_choice.py
+++ b/tests/test_alembic_choice.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p..
+# SPDX-License-Identifier: MIT
+
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from alembic.script import Script
+from mocks import MockEntryPoint
+from sqlalchemy import text
+
+from invenio_db.utils import drop_alembic_version_table
+
+
+def _mock_entry_points(group=None):
+    data = {
+        "invenio_db.models": [
+            MockEntryPoint(
+                name="demo.with_choice", value="demo.with_choice", group="test"
+            ),
+        ],
+        "invenio_db.alembic": [
+            MockEntryPoint(name="demo", value="demo:alembic", group="test"),
+        ],
+    }
+    if group:
+        return data.get(group, [])
+    return data
+
+
+def drop_transaction_table(db):
+    connection = db.engine.connect()
+    connection.execute(text("DROP TABLE IF EXISTS transaction;"))
+    connection.execute(text("DROP SEQUENCE IF EXISTS transaction_id_seq;"))
+    connection.commit()
+    connection.close()
+
+
+@patch("importlib.metadata.entry_points", _mock_entry_points)
+def test_alembic(app, db):
+    """Test alembic recipes."""
+    from invenio_db.ext import InvenioDB
+
+    ext = InvenioDB(app, db=db)
+
+    if db.engine.name == "sqlite":
+        raise pytest.skip("Upgrades are not supported on SQLite.")
+
+    generated_paths = []
+    try:
+        db.drop_all()
+        drop_alembic_version_table()
+        drop_transaction_table(db)
+
+        with app.app_context():
+            # drop transaction table and sequence
+            ext.alembic.upgrade()
+
+            # generate a migration
+            result = ext.alembic.revision(
+                "Initial branch",
+                branch="demo",
+                parent="dbdbc1b19cf2",
+                empty=True,
+                splice=True,
+            )[0]
+            generated_paths.append(result.path)
+            # need to sleep to avoid timestamp collision (hash is computed from timestamp)
+            time.sleep(2)
+            ext.alembic.upgrade()
+            result = ext.alembic.revision("Choice test", branch="demo")[0]
+            generated_paths.append(result.path)
+
+            content = Path(result.path).read_text()
+
+            # check that imports have been added
+            assert "import sqlalchemy_utils" in content
+            assert "import invenio_db.shared" in content
+            assert "from demo.with_choice import Severity" in content
+            assert (
+                "sa.Column('enum_choice', sqlalchemy_utils.types.choice.ChoiceType(Severity, impl=sa.Unicode(length=255))"
+                in content
+            )
+            assert "sa.Column('tuple_choice', sa.Unicode(length=255)" in content
+
+            # upgrade to the new migration to check it works
+            ext.alembic.upgrade()
+
+        # Cleanup
+        db.drop_all()
+        drop_alembic_version_table()
+        drop_transaction_table(db)
+    finally:
+        for path in generated_paths:
+            Path(path).unlink()


### PR DESCRIPTION
### Description

Auto-generating a migration for a model with a `sqlalchemy_utils.ChoiceType`
column produces a broken migration file in two ways:

- The `ChoiceType` is instantiated in the migration file with incorrect arguments
  (`ChoiceType(length=1)` is generated instead of `ChoiceType(Severity, ...)`).
- Some required imports are missing.

As a result, the generated Alembic file must be manually edited to fix these issues.

### Solution

A custom `render_item` hook is registered in `ALEMBIC_CONTEXT` to intercept
`ChoiceType` rendering and emit valid Python code, including the necessary enum
import. The migration template is also updated to always include
`sqlalchemy_utils` and `invenio_db.shared`.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
