### PR TITLE
fix: Flask-Alembic 3.2.0 path separator bug workaround

### DIFF
--- a/invenio_db/ext.py
+++ b/invenio_db/ext.py
@@ -57,6 +57,20 @@ class InvenioAlembic(Alembic):
         """Initialize InvenioAlembic."""
         super().__init__(*args, **kwargs)
 
+    @property
+    def config(self):
+        """Temporary fix for bug in Flask-Alembic 3.2.0.
+
+        Flask-Alembic 3.2.0 sets "os" as path separator in Alembic config but still joins "version_locations" using ',',
+        leading to Alembic failing to split individual alembic version script locations correctly.
+        """
+        cfg = super().config
+        os_pathsep_version_locations = os.pathsep.join(
+            cfg.get_main_option("version_locations").split(",")
+        )
+        cfg.set_main_option("version_locations", os_pathsep_version_locations)
+        return cfg
+
     def _set_lock_timeout(self):
         """Set lock_timeout on all PostgreSQL migration connections."""
         for ctx in self.migration_contexts.values():

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,8 +30,7 @@ python_requires = >=3.7
 zip_safe = False
 install_requires =
     alembic>=1.10.0
-    # https://flask-alembic.readthedocs.io/en/stable/changes/#version-3-2-0 - breaks CI with incompatible changes on the upgrade command
-    Flask-Alembic>=3.0.0,<3.2.0
+    Flask-Alembic>=3.2.0
     Flask-SQLAlchemy>=3.0
     invenio-base>=2.3.0,<3.0.0
     SQLAlchemy-Continuum>=1.3.12,<1.6.0


### PR DESCRIPTION
* Adds workaround ensuring `version_locations` in Alembic config use `os.pathsep` instead of `,` as the path separator.
* Unpins Flask-Alembic to pick up 3.2.0.

:heart: Thank you for your contribution!

### Description

In Flask-Alembic 3.2.0, `version_locations` is declared to use `os.pathsep` as
the separator in Alembic config, but Flask-Alembic still joins multiple version locations with a `,`. As a result, Alembic fails to split the individual version locations correctly.

This PR unpins Flask-Alembic to pick up 3.2.0 and adds a temporary workaround
in `InvenioAlembic` that rewrites `version_locations` to use `os.pathsep` instead of `,` as
the actual separator.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
