### PR TITLE
fix(timestamp): use column-level onupdate for updated field

### DIFF
--- a/invenio_db/shared.py
+++ b/invenio_db/shared.py
@@ -12,7 +12,7 @@
 from datetime import datetime, timezone
 
 from flask_sqlalchemy import SQLAlchemy as FlaskSQLAlchemy
-from sqlalchemy import Column, MetaData, event, util
+from sqlalchemy import Column, MetaData, util
 from sqlalchemy.types import DateTime, TypeDecorator
 
 NAMING_CONVENTION = util.immutabledict(
@@ -79,9 +79,8 @@ class UTCDateTime(TypeDecorator):
 class Timestamp:
     """Adds `created` and `updated` columns to a derived declarative model.
 
-    The `created` column is handled through a default and the `updated`
-    column is handled through a `before_update` event that propagates
-    for all derived declarative models.
+    Both columns are handled via column-level defaults/onupdate, which fire
+    for both ORM-level and bulk SQL UPDATE statements.
 
     ::
 
@@ -99,18 +98,9 @@ class Timestamp:
     updated = Column(
         UTCDateTime,
         default=lambda: datetime.now(tz=timezone.utc),
+        onupdate=lambda: datetime.now(tz=timezone.utc),
         nullable=False,
     )
-
-
-@event.listens_for(Timestamp, "before_update", propagate=True)
-def timestamp_before_update(mapper, connection, target):
-    """Update timestamp on before_update event.
-
-    When a model with a timestamp is updated; force update the updated
-    timestamp.
-    """
-    target.updated = datetime.now(tz=timezone.utc)
 
 
 class SQLAlchemy(FlaskSQLAlchemy):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -361,6 +361,76 @@ def test_local_proxy(app, db):
         assert result == (True, True, True, True)
 
 
+def test_timestamp_bulk_update(db, app):
+    """Test that updated is refreshed when using a bulk Query.update()."""
+    import sqlalchemy as sa
+
+    class TimestampedModel(db.Model, db.Timestamp):
+        __tablename__ = "timestamped"
+        pk = sa.Column(sa.Integer, primary_key=True, autoincrement=True)
+        name = sa.Column(sa.String(50))
+
+    app.config["DB_VERSIONING"] = False
+    InvenioDB(app, entry_point_group=False, db=db)
+
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        obj = TimestampedModel(name="before")
+        db.session.add(obj)
+        db.session.commit()
+
+        updated_before = obj.updated
+
+        db.session.query(TimestampedModel).filter_by(pk=obj.pk).update(
+            {"name": "after"}
+        )
+        db.session.commit()
+
+        db.session.refresh(obj)
+        assert obj.updated > updated_before
+
+        db.session.commit()
+        db.drop_all()
+
+
+def test_timestamp_core_update(db, app):
+    """Test that updated is refreshed when using a Core update statement."""
+    from datetime import datetime, timezone
+
+    class TimestampedModel(db.Model, db.Timestamp):
+        __tablename__ = "timestamped"
+        pk = sa.Column(sa.Integer, primary_key=True, autoincrement=True)
+        name = sa.Column(sa.String(50))
+
+    app.config["DB_VERSIONING"] = False
+    InvenioDB(app, entry_point_group=False, db=db)
+
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        old_timestamp = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        obj = TimestampedModel(
+            name="before", created=old_timestamp, updated=old_timestamp
+        )
+        db.session.add(obj)
+        db.session.commit()
+
+        db.session.execute(
+            sa.update(TimestampedModel)
+            .where(TimestampedModel.pk == obj.pk)
+            .values(name="after")
+        )
+        db.session.commit()
+
+        db.session.refresh(obj)
+        assert obj.name == "after"
+        assert obj.updated > old_timestamp
+
+        db.session.commit()
+        db.drop_all()
+
+
 def test_db_create_alembic_upgrade(app, db):
     """Test that 'db create/drop' and 'alembic create' are compatible.
 


### PR DESCRIPTION
See https://github.com/inveniosoftware/invenio-pages/pull/119#issuecomment-4595920749

:heart: Thank you for your contribution!

### Description

When a model using Timestamp is updated via a direct SQL bulk update (e.g. Query.update()), the updated field was not refreshed
  — the ORM event that handles this is simply not triggered in that case.

This fixes it by adding an onupdate default directly on the updated column, which SQLAlchemy applies to every UPDATE statement
  regardless of how it is issued. The ORM event is no longer needed and has been removed.

Motivated by [inveniosoftware/invenio-pages#119](https://github.com/inveniosoftware/invenio-pages/pull/119), where the same pattern appeared.



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [X] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [X] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [X] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
