### PR TITLE
fix(timezone): slightly relax the UTC timezone check

### DIFF
--- a/invenio_db/shared.py
+++ b/invenio_db/shared.py
@@ -47,7 +47,7 @@ class UTCDateTime(TypeDecorator):
             msg = f"ERROR: value: {value} is not of type datetime, instead of type: {type(value)}"
             raise ValueError(msg)
 
-        if value.tzinfo not in (None, timezone.utc):
+        if value.tzinfo is not None and value.tzname() != "UTC":
             msg = f"Error: value: {value}, tzinfo: {value.tzinfo} doesn't have a tzinfo of None or timezone.utc."
             raise ValueError(msg)
 


### PR DESCRIPTION
Related to https://github.com/inveniosoftware/invenio-banners/pull/76

As `pendulum` uses its own set of classes and objects (adhering to the same interfaces as `datetime` things, due to them being used in inheritance), we're limiting ourselves with the check against exactly `datetime.timezone.utc`.

```python
In [1]: from datetime import datetime, timezone

In [2]: import pendulum

In [3]: p_now = pendulum.now(tz=pendulum.UTC)

In [4]: p_now
Out[4]: DateTime(2026, 7, 4, 17, 9, 3, 510936, tzinfo=Timezone('UTC'))

In [5]: p_now.tzname()
Out[5]: 'UTC'

In [6]: p_now.tzinfo
Out[6]: Timezone('UTC')

In [7]: d_now = datetime.now(tz=timezone.utc)

In [8]: d_now
Out[8]: datetime.datetime(2026, 7, 4, 17, 9, 19, 758340, tzinfo=datetime.timezone.utc)

In [9]: d_now.tzname()
Out[9]: 'UTC'

In [10]: d_now.tzinfo
Out[10]: datetime.timezone.utc

In [11]: p_now == d_now
Out[11]: False
```