### PR TITLE
chore(setup): replace psycopg2-binary with psycopg2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ mysql = [
   "pymysql>=0.10.1",
 ]
 postgresql = [
-  "psycopg2-binary>=2.8.6",
+  "psycopg2>=2.8.6",
 ]
 tests = [
   "cryptography>=2.1.4",


### PR DESCRIPTION
Building the package from source does not cost a lot, and even the maintainers themselves state that it's the preferred way to use psycopg2 in production:
> The binary package is a practical choice for development and testing but in production it is advised to use the package built from sources.

https://pypi.org/project/psycopg2-binary/

Also, this enables installation with free-threading Python, e.g. `3.14t`.

**Note**: This adds the requirement of `pg_config` (e.g. packaged in `postgresql-dev` at times) to build.