### PR TITLE
fix(alembic): ignore the new "checkconstraint_byname" plugin for now

### DIFF
--- a/invenio_db/ext.py
+++ b/invenio_db/ext.py
@@ -126,6 +126,13 @@ class InvenioDB(object):
             {
                 "transaction_per_migration": True,
                 "compare_type": True,  # Allows to detect change of column type, accuracy depends on backend
+                "autogenerate_plugins": [
+                    # Alembic v1.19.0 introduced the a new CHECK constraint plugin which causes
+                    # a few hiccups in our setup, so we disable it for now
+                    # cf. https://alembic.sqlalchemy.org/en/latest/changelog.html#change-1.19.0
+                    "alembic.autogenerate.*",
+                    "~alembic.autogenerate.checkconstraint_byname",
+                ],
             },
         )
 

--- a/invenio_db/utils.py
+++ b/invenio_db/utils.py
@@ -122,6 +122,13 @@ def alembic_test_context():
         "transaction_per_migration": True,
         "include_object": include_object,
         "compare_server_default": True,
+        "autogenerate_plugins": [
+            # Alembic v1.19.0 introduced the a new CHECK constraint plugin which causes
+            # a few hiccups in our setup, so we disable it for now
+            # cf. https://alembic.sqlalchemy.org/en/latest/changelog.html#change-1.19.0
+            "alembic.autogenerate.*",
+            "~alembic.autogenerate.checkconstraint_byname",
+        ],
     }
 
 


### PR DESCRIPTION
* this new plugin causes a few hiccups like failures of alembic tests in our packages, so we disable it for now
* in the future, we may consider looking into alternatives to this approach

Supersedes https://github.com/inveniosoftware/invenio-rdm-records/pull/2425

This basically follows the recommendation from the [`alembic` docs](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#detecting-check-constraints) by simply disabling the new plugin.
In the future, we might consider finding a "better" fix for the test failures.

---

`Alembic` forwards extra unexpected keyword arguments for `EnvironmentContext.configure()` [1] to `MigrationContext.__init__()` [2] where they simply don't get used.
So this should be fine with older versions of `alembic` as well; which aligns the lack of issues I found with some manual test runs with 0.18.5.

[1] https://github.com/sqlalchemy/alembic/blob/rel_1_18_5/alembic/runtime/environment.py#L936
[2] https://github.com/sqlalchemy/alembic/blob/main/alembic/runtime/migration.py#L131

---

Testrig run: https://max-moser.github.io/invenio-testrig-client/invenio-testrig-2026-08-05-16-18-00/

<img width="1362" height="712" alt="image" src="https://github.com/user-attachments/assets/2cceee0a-70b3-4c20-824c-c9e7d7179864" />
